### PR TITLE
Change behaviour of an `output` argument in `Converter`, `Converter::JSON` and `Converter::CSV` `.convert` methods

### DIFF
--- a/lib/ronin/masscan/converter.rb
+++ b/lib/ronin/masscan/converter.rb
@@ -100,7 +100,7 @@ module Ronin
           Converters[format].convert(masscan_file,output)
         else
           output = StringIO.new
-          convert(masscan_file,output, format:)
+          convert(masscan_file,output, format: format)
           output.string
         end
       end

--- a/lib/ronin/masscan/converter.rb
+++ b/lib/ronin/masscan/converter.rb
@@ -90,7 +90,7 @@ module Ronin
       # @param [:json, :csv] format
       #   The desired convert to convert the parsed masscan scan file to.
       #
-      # @return [String]
+      # @return [IO, String]
       #   The converted masscan scan file.
       #
       # @api public

--- a/lib/ronin/masscan/converter.rb
+++ b/lib/ronin/masscan/converter.rb
@@ -96,7 +96,7 @@ module Ronin
       # @api public
       #
       def self.convert(masscan_file,output=nil, format: )
-        Converters[format].convert(masscan_file,output)
+        Converters[format].convert(masscan_file,*output)
       end
 
       #

--- a/lib/ronin/masscan/converter.rb
+++ b/lib/ronin/masscan/converter.rb
@@ -84,7 +84,7 @@ module Ronin
       # @param [::Masscan::OutputFile] masscan_file
       #   The masscan scan file to convert.
       #
-      # @param [IO, String, nil] output
+      # @param [IO, nil] output
       #   Optional output to write the converted output to.
       #
       # @param [:json, :csv] format
@@ -96,7 +96,13 @@ module Ronin
       # @api public
       #
       def self.convert(masscan_file,output=nil, format: )
-        Converters[format].convert(masscan_file,*output)
+        if output
+          Converters[format].convert(masscan_file,output)
+        else
+          output = StringIO.new
+          convert(masscan_file,output, format:)
+          output.string
+        end
       end
 
       #

--- a/lib/ronin/masscan/converters/csv.rb
+++ b/lib/ronin/masscan/converters/csv.rb
@@ -27,6 +27,8 @@ module Ronin
       #
       # Handles converting masscan scan files into CSV.
       #
+      # @api private
+      #
       module CSV
         #
         # Converts the masscan scan file to CSV.
@@ -34,13 +36,13 @@ module Ronin
         # @param [::Masscan::OutputFile] masscan_file
         #   The opened masscan scan file.
         #
-        # @param [String, IO] output
+        # @param [StringIO, IO] output
         #   Optional output stream to write the CSV to.
         #
         # @return [String]
         #   The raw CSV.
         #
-        def self.convert(masscan_file,output=String.new)
+        def self.convert(masscan_file,output)
           masscan_file_to_csv(masscan_file,output)
         end
 
@@ -50,13 +52,13 @@ module Ronin
         # @param [::Masscan::OutputFile] masscan_file
         #   The masscan scan file to convert to CSV.
         #
-        # @param [String, IO] output
+        # @param [StringIO, IO] output
         #   The optional output to write the CSV to.
         #
-        # @return [String, IO]
+        # @return [StringIO, IO]
         #   The CSV output.
         #
-        def self.masscan_file_to_csv(masscan_file,output=String.new)
+        def self.masscan_file_to_csv(masscan_file,output)
           masscan_file_to_rows(masscan_file) do |row|
             output << ::CSV.generate_line(row)
           end

--- a/lib/ronin/masscan/converters/csv.rb
+++ b/lib/ronin/masscan/converters/csv.rb
@@ -39,9 +39,6 @@ module Ronin
         # @param [StringIO, IO] output
         #   Optional output stream to write the CSV to.
         #
-        # @return [String]
-        #   The raw CSV.
-        #
         def self.convert(masscan_file,output)
           masscan_file_to_csv(masscan_file,output)
         end
@@ -55,8 +52,6 @@ module Ronin
         # @param [StringIO, IO] output
         #   The optional output to write the CSV to.
         #
-        # @return [StringIO, IO]
-        #   The CSV output.
         #
         def self.masscan_file_to_csv(masscan_file,output)
           masscan_file_to_rows(masscan_file) do |row|

--- a/lib/ronin/masscan/converters/json.rb
+++ b/lib/ronin/masscan/converters/json.rb
@@ -39,9 +39,6 @@ module Ronin
         # @param [IO, StringIO] output
         #   Optional output stream to write the JSON to.
         #
-        # @return [String]
-        #   The raw JSON.
-        #
         def self.convert(masscan_file,output)
           masscan_file_to_json(masscan_file,output)
         end
@@ -54,9 +51,6 @@ module Ronin
         #
         # @param [IO, StringIO] output
         #   Optional output stream to write the JSON to.
-        #
-        # @return [String]
-        #   The raw JSON.
         #
         def self.masscan_file_to_json(masscan_file,output)
           ::JSON.dump(masscan_file_as_json(masscan_file),output)

--- a/lib/ronin/masscan/converters/json.rb
+++ b/lib/ronin/masscan/converters/json.rb
@@ -27,6 +27,8 @@ module Ronin
       #
       # Handles converting masscan scan files into JSON.
       #
+      # @api private
+      #
       module JSON
         #
         # Converts the masscan scan file to JSON.
@@ -34,13 +36,13 @@ module Ronin
         # @param [::Masscan::OutputFile] masscan_file
         #   The opened masscan scan file.
         #
-        # @param [IO, nil] output
+        # @param [IO, StringIO] output
         #   Optional output stream to write the JSON to.
         #
         # @return [String]
         #   The raw JSON.
         #
-        def self.convert(masscan_file,output=nil)
+        def self.convert(masscan_file,output)
           masscan_file_to_json(masscan_file,output)
         end
 
@@ -50,13 +52,13 @@ module Ronin
         # @param [::Masscan::OutputFile] masscan_file
         #   The opened masscan scan file.
         #
-        # @param [IO, nil] output
+        # @param [IO, StringIO] output
         #   Optional output stream to write the JSON to.
         #
         # @return [String]
         #   The raw JSON.
         #
-        def self.masscan_file_to_json(masscan_file,output=nil)
+        def self.masscan_file_to_json(masscan_file,output)
           ::JSON.dump(masscan_file_as_json(masscan_file),output)
         end
 


### PR DESCRIPTION
It causes `undefined method '<<' for nil:NilClass` in `CSV.convert`