### PR TITLE
Fix `Masscan.scan` output file path

### DIFF
--- a/lib/ronin/masscan.rb
+++ b/lib/ronin/masscan.rb
@@ -63,7 +63,7 @@ module Ronin
 
       unless masscan.output_file
         FileUtils.mkdir_p(CACHE_DIR)
-        tempfile = Tempfile.new('masscan', CACHE_DIR)
+        tempfile = Tempfile.new(['masscan', '.json'], CACHE_DIR)
 
         masscan.output_file = tempfile.path
       end

--- a/lib/ronin/masscan.rb
+++ b/lib/ronin/masscan.rb
@@ -71,7 +71,7 @@ module Ronin
       status  = masscan.run_command
 
       if status
-        return ::Masscan::OutputFile.new(tempfile.path)
+        return ::Masscan::OutputFile.new(masscan.output_file)
       else
         return status
       end


### PR DESCRIPTION
`tempfile.path` is valid only if `output_file` is not specified

Also file extensions needs to be specified because of [this](https://github.com/postmodern/ruby-masscan/blob/3e41aa38bc2aa8f6c818b62c68a010ba4b91fd49/lib/masscan/output_file.rb#L99).